### PR TITLE
connect to host relative uri

### DIFF
--- a/src/api/web-socket.js
+++ b/src/api/web-socket.js
@@ -1,5 +1,5 @@
 import openSocket from 'socket.io-client'
-const socket = openSocket('http://localhost:8282')
+const socket = openSocket('/')
 
 export const subscribeToChannel = (channel, opts, cb) => {
   socket.on(channel, message => cb(message))


### PR DESCRIPTION
If you start the nats-streaming-console in a docker container and remap to http port, the website will no be able to connect due to hardcoded socket uri - use host relative uri instead.